### PR TITLE
Framer motion: Reduce wait time b/w parent and children animation with restDelta…

### DIFF
--- a/src/framer-motion-example.js
+++ b/src/framer-motion-example.js
@@ -4,7 +4,9 @@ import React from 'react'
 const springConfig = {
   type: 'spring',
   stiffness: 200,
-  damping: 13
+  damping: 13,
+  restDelta: 4,
+  restSpeed: 4
 }
 
 const containerConfig = {


### PR DESCRIPTION
> I do wish it was possible to minimize the wait time between the parent and child animations.

Not sure if this is what you had in mind, but in a way it is (now) possible to reduce the wait time between parent and child animations in your example by increasing `restSpeed` and `restDelta`

By the way, thank you for this great comparison!